### PR TITLE
Added support for DC3231 battery backup clock module

### DIFF
--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -9,6 +9,18 @@
 #include "rtc_hal.hpp"
 #include "settings.hpp"
 
+#define UseDS3232
+
+#ifdef UseDS3232
+  #include <DS3231.h>
+  #include <Wire.h>
+  
+  DS3231 BackupClock;
+  bool h12;
+  bool PM;
+#endif
+
+
 Settings *Settings::m_inst = nullptr;
 CmdHandler *CmdHandler::m_inst = nullptr;
 
@@ -54,6 +66,11 @@ void setup()
 
         // Settings::Save(); // UNCOMMENT to save these settings into flash
     }
+
+    #ifdef UseDS3232
+      // Set time via wire to DS3231
+      rtc_hal_setTime( BackupClock.getHour(h12, PM),  BackupClock.getMinute(),  BackupClock.getSecond());
+    #endif
 
     Adafruit_NeoPixel leds(NUM_LEDS, PIN_LEDS, NEO_GRB + NEO_KHZ400);
     leds.begin(); // initialize NeoPixel library
@@ -119,6 +136,12 @@ void setup()
         if (evt == Button::RELEASE)
         {
             rtc_hal_setTime(rtc_hal_hour() + 1, rtc_hal_minute(), rtc_hal_second());
+            #ifdef UseDS3232
+              // Set thte DS3231 to the current displayed time
+              BackupClock.setHour(rtc_hal_hour());
+              BackupClock.setMinute(rtc_hal_minute());
+              BackupClock.setSecond(rtc_hal_second());
+            #endif
             clock.Draw();
         }
     });
@@ -127,6 +150,12 @@ void setup()
         if (evt == Button::RELEASE || evt == Button::REPEAT)
         {
             rtc_hal_setTime(rtc_hal_hour(), rtc_hal_minute() + 1, rtc_hal_second());
+            #ifdef UseDS3232
+              // Set thte DS3231 to the current displayed time
+              BackupClock.setHour(rtc_hal_hour());
+              BackupClock.setMinute(rtc_hal_minute());
+              BackupClock.setSecond(rtc_hal_second());
+            #endif
             clock.Draw();
         }
     });

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -28,7 +28,7 @@ enum HardwareConfig_e
 
 void setup()
 {
-    // Serial.begin(115200);
+    Serial.begin(115200);
 
     Settings settings;
     if (false) // change to 'true' to allow the below code to change the settings on boot

--- a/firmware/firmware.ino
+++ b/firmware/firmware.ino
@@ -9,18 +9,6 @@
 #include "rtc_hal.hpp"
 #include "settings.hpp"
 
-#define UseDS3232
-
-#ifdef UseDS3232
-  #include <DS3231.h>
-  #include <Wire.h>
-  
-  DS3231 BackupClock;
-  bool h12;
-  bool PM;
-#endif
-
-
 Settings *Settings::m_inst = nullptr;
 CmdHandler *CmdHandler::m_inst = nullptr;
 
@@ -67,10 +55,7 @@ void setup()
         // Settings::Save(); // UNCOMMENT to save these settings into flash
     }
 
-    #ifdef UseDS3232
-      // Set time via wire to DS3231
-      rtc_hal_setTime( BackupClock.getHour(h12, PM),  BackupClock.getMinute(),  BackupClock.getSecond());
-    #endif
+    rtc_hal_init();
 
     Adafruit_NeoPixel leds(NUM_LEDS, PIN_LEDS, NEO_GRB + NEO_KHZ400);
     leds.begin(); // initialize NeoPixel library
@@ -136,12 +121,6 @@ void setup()
         if (evt == Button::RELEASE)
         {
             rtc_hal_setTime(rtc_hal_hour() + 1, rtc_hal_minute(), rtc_hal_second());
-            #ifdef UseDS3232
-              // Set thte DS3231 to the current displayed time
-              BackupClock.setHour(rtc_hal_hour());
-              BackupClock.setMinute(rtc_hal_minute());
-              BackupClock.setSecond(rtc_hal_second());
-            #endif
             clock.Draw();
         }
     });
@@ -150,12 +129,6 @@ void setup()
         if (evt == Button::RELEASE || evt == Button::REPEAT)
         {
             rtc_hal_setTime(rtc_hal_hour(), rtc_hal_minute() + 1, rtc_hal_second());
-            #ifdef UseDS3232
-              // Set thte DS3231 to the current displayed time
-              BackupClock.setHour(rtc_hal_hour());
-              BackupClock.setMinute(rtc_hal_minute());
-              BackupClock.setSecond(rtc_hal_second());
-            #endif
             clock.Draw();
         }
     });

--- a/firmware/rtc_hal_apollo3.cpp
+++ b/firmware/rtc_hal_apollo3.cpp
@@ -1,12 +1,27 @@
 #include "rtc_hal.hpp"
 #include <RTC.h>
+#define UseDS3232
+
+#ifdef UseDS3232
+  #include <DS3231.h>
+  #include <Wire.h>
+  
+  DS3231 BackupClock;
+  bool h12;
+  bool PM;
+#endif
+
 
 APM3_RTC g_rtc;
 void rtc_hal_init()
 {
     // force a specific time on boot if desired
     // rtc_hal_setTime() ...
+    
+    #ifdef UseDS3232
 
+    #endif
+    
     rtc_hal_update();
 }
 
@@ -44,6 +59,14 @@ void rtc_hal_setTime(int h, int m, int s)
     s = (s >= 60 ? 0 : s);
 
     g_rtc.setTime(h, m, s, 0, g_rtc.dayOfMonth, g_rtc.month, g_rtc.year);
+
+    #ifdef UseDS3232
+      // Set thte DS3231 to the current displayed time
+      BackupClock.setHour(rtc_hal_hour());
+      BackupClock.setMinute(rtc_hal_minute());
+      BackupClock.setSecond(rtc_hal_second());
+    #endif
+    
     rtc_hal_update();
 }
 

--- a/firmware/rtc_hal_apollo3.cpp
+++ b/firmware/rtc_hal_apollo3.cpp
@@ -1,5 +1,7 @@
 #include "rtc_hal.hpp"
 #include <RTC.h>
+
+
 #define UseDS3232
 
 #ifdef UseDS3232
@@ -23,6 +25,7 @@ void rtc_hal_init()
 
     
      #ifdef UseDS3232
+      Wire.begin();
       rtc_hal_setTime(BackupClock.getHour(h12, PM), BackupClock.getMinute(), BackupClock.getSecond());
     #endif
 

--- a/firmware/rtc_hal_apollo3.cpp
+++ b/firmware/rtc_hal_apollo3.cpp
@@ -18,11 +18,14 @@ void rtc_hal_init()
     // force a specific time on boot if desired
     // rtc_hal_setTime() ...
     
-    #ifdef UseDS3232
-
-    #endif
-    
+       
     rtc_hal_update();
+
+    
+     #ifdef UseDS3232
+      rtc_hal_setTime(BackupClock.getHour(h12, PM), BackupClock.getMinute(), BackupClock.getSecond());
+    #endif
+
 }
 
 void rtc_hal_update()
@@ -59,15 +62,15 @@ void rtc_hal_setTime(int h, int m, int s)
     s = (s >= 60 ? 0 : s);
 
     g_rtc.setTime(h, m, s, 0, g_rtc.dayOfMonth, g_rtc.month, g_rtc.year);
+    
+    rtc_hal_update();
 
-    #ifdef UseDS3232
+     #ifdef UseDS3232
       // Set thte DS3231 to the current displayed time
       BackupClock.setHour(rtc_hal_hour());
       BackupClock.setMinute(rtc_hal_minute());
       BackupClock.setSecond(rtc_hal_second());
     #endif
-    
-    rtc_hal_update();
 }
 
 void rtc_hal_setDate(int d, int m, int y)


### PR DESCRIPTION
Added support for a battery backed up DS3231 over I2C.   Automatically since time with DS3231 at startup and when time is changed via buttons.


